### PR TITLE
Add instructions for the three subdomains of 'i use this'

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -1945,6 +1945,36 @@
     },
 
     {
+        "name": "i use this (iPhone)",
+        "url": "http://iphone.iusethis.com/user/delete_user",
+        "difficulty": "easy",
+        "notes": "Deleting this account will also delete your Mac and Windows accounts on 'i use this', if you have them set up.",
+        "domains": [
+            "iphone.iusethis.com",
+        ]
+    },
+
+    {
+        "name": "i use this (Mac)",
+        "url": "http://osx.iusethis.com/user/delete_user",
+        "difficulty": "easy",
+        "notes": "Deleting this account will also delete your iPhone and Windows accounts on 'i use this', if you have them set up.",
+        "domains": [
+            "osx.iusethis.com",
+        ]
+    },
+
+    {
+        "name": "i use this (Windows)",
+        "url": "http://windows.iusethis.com/user/delete_user",
+        "difficulty": "easy",
+        "notes": "Deleting this account will also delete your iPhone and Mac accounts on 'i use this', if you have them set up.",
+        "domains": [
+            "windows.iusethis.com",
+        ]
+    },
+
+    {
         "name": "Iceber.gs",
         "url": "https://iceber.gs/home",
         "difficulty": "easy",


### PR DESCRIPTION
This was an awkward one. Deleting your account is easy once you log in. Unfortunately there are three subdomains to the site, and you can't use the "delete" link on one of the subdomains unless you're logged in on that subdomain. Hence I put three separate entries in `sites.json` and included a note saying that deleting your account from one subdomain will also delete it from the other two.

What a headache.