### PR TITLE
Add site information for douban.com

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -975,6 +975,15 @@
     },
 
     {
+        "name": "Douban",
+        "url": "http://www.douban.com/accounts/suicide/",
+        "difficulty": "easy",
+        "domains": [
+            "douban.com"
+        ]
+    },
+
+    {
         "name": "DOWN",
         "url": "https://bangwithfriends.zendesk.com/hc/en-us/articles/201441976-Deleting-Your-Account",
         "difficulty": "medium",


### PR DESCRIPTION
The [Douban (豆瓣)](http://www.douban.com) is a Chinese social network site.

Please review my changes. Thank you.