### PR TITLE
Updated URL for Code School to fix 404

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -657,7 +657,7 @@
 
     {
         "name": "Code School",
-        "url": "http://help.codeschool.com/kb/codeschool-faqs/account-questions",
+        "url": "https://codeschool.reamaze.com/kb/general/how-do-i-delete-my-code-school-account",
         "difficulty": "medium",
         "notes": "Start a private discussion with them and they will 'take care of it'.",
         "notes_fr": "Posez leur la question pour qu'ils vous prennent en charge.",


### PR DESCRIPTION
Fixes #434.

Code School have moved their help pages (from help.codeschool.com.com to codeschool.reamaze.com) and the URL has been updated to reflect this.