### PR TITLE
Update sites.json

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -250,6 +250,16 @@
     },
 
     {
+        "name": "Backblaze",
+        "url": "https://secure.backblaze.com/user_account.htm",
+        "difficulty": "impossible",
+        "notes": "Accounts cannot be deleted, even when contacting customer service. User account credentials will be permanently retained by Backblaze.",
+        "domains": [
+            "backblaze.com"
+        ]
+    },
+
+    {
         "name": "Badoo",
         "url": "http://badoo.com/settings/",
         "difficulty": "easy",


### PR DESCRIPTION
Added site Backblaze. Information sourced from customer service representative, who stated:

"The account is now inactive and you will receive no further communication from Backblaze. As per our terms, the account credentials will be retained by Backblaze."