### PR TITLE
Added PCPartPicker

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -3138,6 +3138,15 @@
             "paypal.com"
         ]
     },
+	{
+        "name": "PCPartPicker",
+        "url": "http://pcpartpicker.com/contact/",
+        "difficulty": "hard",
+        "notes": "I had to contact via email, but they then immediately deleted my account",
+        "domains": [
+            "pcpartpicker.com"
+        ]
+    },
 
     {
         "name": "Personello Germany",


### PR DESCRIPTION
I took a punt with the email address I contacted, so I've left out the email field. If someone from PPP can help that'd be handy.

If you do want to include the email I used, it was ryan@pcpartpicker.com.