### PR TITLE
Change PayPal to Hard Classification, fixes #464

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -2526,7 +2526,7 @@
     {
         "name": "PayPal",
         "url": "https://www.paypal.com/us/cgi-bin/webscr?cmd=_close-account",
-        "difficulty": "easy",
+        "difficulty": "hard",
         "notes": "Log in. Click 'Profile' near the top of the page. Click 'My settings'. Click 'Close Account' in the 'Account type' section and follow the steps listed.",
         "domains": [
             "paypal.com"


### PR DESCRIPTION
This person had a point, read their comment. ("it" meaning PayPal)

Cattze2015 commented on 10 Jan
"Change it to "Cannot be fully deleted without contacting customer-services"(red).

Newly create an account with no credit card will be locked by PayPal.
It's impossible without contacting PayPal by phone to delete it."

And again you can use the delete button in the "Account Options" page, here is what they said.

Cattze2015 commented on 10 Jan
"Also, they never delete your information. You can confirm what I'm saying by calling them directly.

They simply close your account with everything inside(your personal information).
I'm surprised to notice that they still hold my old accounts(over several years ago).

Paypal should not be green. This is not a "delete"."