### PR TITLE
Update CloudApp to hard

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -681,7 +681,9 @@
     {
         "name": "CloudApp",
         "url": "http://my.cl.ly/account/delete",
-        "difficulty": "easy",
+        "email": "support@getcloudapp.com",
+        "difficulty": "hard",
+        "notes": "The site claims that you must call their support line (888-988-5036, ext 1), but they deactivated my account over email.",
         "domains": [
             "my.cl.ly",
             "cl.ly"


### PR DESCRIPTION
Unfortunately, the URL currently linked now responds with an error instructing users to call their support line. They "deactivated" my account over email, but my email address seems to still be recognized, so it's clearly not deleted.