### PR TITLE
Updated Instagram URL to permanent delete

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -2327,7 +2327,7 @@
     {
         "meta": "popular",
         "name": "Instagram",
-        "url": "https://instagram.com/accounts/remove/request",
+        "url": "https://instagram.com/accounts/remove/request/permanent/",
         "difficulty": "easy",
         "domains": [
             "instagram.com"


### PR DESCRIPTION
The old URL only suspends account, the new URL permanently deletes the account. #525 