### PR TITLE
Changed Spotify to "easy".

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -4651,13 +4651,6 @@
         "name": "Spotify",
         "url": "https://support.spotify.com/close/",
         "difficulty": "easy",
-        "notes": "Login in. Click on "CLOSE MY ACCOUNT".",
-        "notes_fr": "Vous devez vous identifier. Cliquez sur "FERMER MON COMPTE".",
-        "notes_it": "Accedi. Fare clic su "CHIUDI IL MIO ACCOUNT".",
-        "notes_pt_br": "Entre in. Clique em "FECHAR MINHA CONTA".",
-        "notes_cat": "Inicia sessió. Feu clic a "TANCAR EL MEU COMPTE".",
-        "notes_es": "Inicia sesión. Haga clic en "CERRAR MI CUENTA".",
-        "notes_pl": "Zaloguj się. Kliknij na "ZAMKNIJ KONTO".",
         "domains": [
             "spotify.com",
             "support.spotify.com"

--- a/sites.json
+++ b/sites.json
@@ -4649,17 +4649,18 @@
 
     {
         "name": "Spotify",
-        "url": "https://www.spotify.com/se/about-us/contact/contact-spotify-support/?contact",
-        "difficulty": "hard",
-        "notes": "Contact Spotify’s customer services through their contact form and request for your account to be closed.",
-        "notes_fr": "Contactez le service clients en lui demandant la suppression de votre compte.",
-        "notes_it": "Contatta l'assistenza clienta di Spotify attraverso il loro modulo e richiedi la cancellazione dell'account.",
-        "notes_pt_br": "Contate a assistência ao cliente da Spotify através do formulário de contato e peça o fechamento da sua conta.",
-        "notes_cat": "Contacti amb l'assistència al client d'Spotify a través del formulari de contacte i demana el clausurament del compte.",
-        "notes_es": "Contacta con asistencia al cliente de Spotify a través del formulario de contacto y pide que cierren la cuenta.",
-        "notes_pl": "Skontaktuj się z obsługą techniczną poprzez formularz kontaktowy i poproś o usunięcie konta.",
+        "url": "https://support.spotify.com/close/",
+        "difficulty": "easy",
+        "notes": "Login in. Click on "CLOSE MY ACCOUNT".",
+        "notes_fr": "Vous devez vous identifier. Cliquez sur "FERMER MON COMPTE".",
+        "notes_it": "Accedi. Fare clic su "CHIUDI IL MIO ACCOUNT".",
+        "notes_pt_br": "Entre in. Clique em "FECHAR MINHA CONTA".",
+        "notes_cat": "Inicia sessió. Feu clic a "TANCAR EL MEU COMPTE".",
+        "notes_es": "Inicia sesión. Haga clic en "CERRAR MI CUENTA".",
+        "notes_pl": "Zaloguj się. Kliknij na "ZAMKNIJ KONTO".",
         "domains": [
-            "spotify.com"
+            "spotify.com",
+            "support.spotify.com"
         ]
     },
 


### PR DESCRIPTION
You can now delete your Spotify account with a direct link. No need anymore to contact Support and request account deletion.

The direct deletion link is found in the new TOS: https://www.spotify.com/us/legal/end-user-agreement/#s2