### PR TITLE
Add Uniqlo

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -5161,6 +5161,16 @@
     },
 
     {
+        "name": "Uniqlo",
+        "url": "https://www.uniqlo.com/",
+        "difficulty": "easy",
+        "notes": "Login, then click 'Delete your account' at the bottom of the account profile page.",
+        "domains": [
+            "uniqlo.com"
+        ]
+    },
+
+    {
         "name": "Unroll.me",
         "url": "https://unroll.me/user/settings",
         "difficulty": "easy",


### PR DESCRIPTION
Link to the website front page because there's no direct link to the profile page (which includes user data) and no help page, but the process is easy enough.