### PR TITLE
Fixes the text not wrapping in its placeholder

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -455,6 +455,7 @@ button {
 	font-size: 12px;
 	margin: 0;
 	color: #293840;
+	word-wrap: break-word;
 	display: none;
 }
 


### PR DESCRIPTION
When clicking "Show info" and when the text is more than its placeholder, the text is not wrapping on it. This should fix the issue.