### PR TITLE
Remove Tweetdeck

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -5051,15 +5051,6 @@
     },
 
     {
-        "name": "Tweetdeck",
-        "url": "https://www.tweetdeck.com/api/account-delete/",
-        "difficulty": "easy",
-        "domains": [
-            "tweetdeck.com"
-        ]
-    },
-
-    {
         "name": "Twenty20",
         "url": "https://www.twenty20.com/delete-account?t20p=settings.index",
         "difficulty": "easy",


### PR DESCRIPTION
Tweetdeck has became a part of official twitter.com site and there are no Tweetdeck accounts anymore. :boom: 